### PR TITLE
change panel setting index in start sequence

### DIFF
--- a/adafruit_uc8253.py
+++ b/adafruit_uc8253.py
@@ -61,7 +61,7 @@ class UC8253(EPaperDisplay):
             panel_setting = 0b11011111
 
         start_sequence[4] = vcom_cdi
-        start_sequence[-1] = panel_setting
+        start_sequence[7] = panel_setting
 
         super().__init__(
             bus,


### PR DESCRIPTION
previously it would show as garbled dark grey instead of white. 